### PR TITLE
Add efficient range function for integral types

### DIFF
--- a/include/openrand/philox.h
+++ b/include/openrand/philox.h
@@ -62,8 +62,8 @@ class Philox : public BaseRNG<Philox> {
    * @param ctr1 (Optional) Another 32-bit counter exposed for advanced use.
    */
   DEVICE Philox(uint64_t seed, uint32_t ctr,
-                 uint32_t global_seed = openrand::DEFAULT_GLOBAL_SEED,
-                 uint32_t ctr1 = 0x12345)
+                uint32_t global_seed = openrand::DEFAULT_GLOBAL_SEED,
+                uint32_t ctr1 = 0x12345)
       : seed_hi((uint32_t)(seed >> 32)),
         seed_lo((uint32_t)(seed & 0xFFFFFFFF)),
         ctr0(ctr),
@@ -76,8 +76,7 @@ class Philox : public BaseRNG<Philox> {
     generate();
 
     static_assert(std::is_same_v<T, uint32_t> || std::is_same_v<T, uint64_t>);
-    if constexpr (std::is_same_v<T, uint32_t>)
-      return _out[0];
+    if constexpr (std::is_same_v<T, uint32_t>) return _out[0];
 
     // Not wrapping this block in else{} would lead to compiler warning
     else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,9 +21,19 @@ target_link_libraries(
   GTest::gtest_main
 )
 
+add_executable(
+  base
+  test_base.cpp
+)
+target_link_libraries(
+  base
+  GTest::gtest_main
+)
+
 include(GoogleTest)
 gtest_discover_tests(uniform)
 gtest_discover_tests(normal)
+gtest_discover_tests(base)
 
 
 # Statistical tests, not run through gtest framework

--- a/tests/test_base.cpp
+++ b/tests/test_base.cpp
@@ -1,0 +1,62 @@
+// @HEADER
+// *******************************************************************************
+//                                OpenRAND                                       *
+//   A Performance Portable, Reproducible Random Number Generation Library       *
+//                                                                               *
+// Copyright (c) 2023, Michigan State University                                 *
+//                                                                               *
+// Permission is hereby granted, free of charge, to any person obtaining a copy  *
+// of this software and associated documentation files (the "Software"), to deal *
+// in the Software without restriction, including without limitation the rights  *
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell     *
+// copies of the Software, and to permit persons to whom the Software is         *
+// furnished to do so, subject to the following conditions:                      *
+//                                                                               *
+// The above copyright notice and this permission notice shall be included in    *
+// all copies or substantial portions of the Software.                           *
+//                                                                               *
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR    *
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,      *
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE   *
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER        *
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, *
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE *
+// SOFTWARE.                                                                     *
+//********************************************************************************
+// @HEADER
+
+#include <gtest/gtest.h>
+#include <openrand/philox.h>
+#include <openrand/squares.h>
+#include <openrand/threefry.h>
+#include <openrand/tyche.h>
+
+#include <random>
+
+template <typename RNG>
+void test_rangev2(int seed) {
+  RNG rng(seed, 0);
+  for (int i = 0; i < 10; i++) {
+    ASSERT_LT(rng.range(10), 10);
+  }
+  const int v = (1 << 27);
+  for (int i = 0; i < 10; i++) {
+    // had to create tmp variable. Couldn't directly pass to ASSERT_LT for
+    // some reason
+    auto x = rng.template range<true, int>(10);
+    ASSERT_LT(x, 10);
+    auto y = rng.template range<true, int>(v);
+    ASSERT_LT(y, v);
+  }
+  for (int i = 0; i < 10; i++) {
+    auto z = rng.template range<true, short>(1000);
+    ASSERT_LT(z, 1000);
+  }
+}
+
+TEST(BASE, rangev2) {
+  test_rangev2<openrand::Philox>(42);
+  test_rangev2<openrand::Tyche>(37);
+  test_rangev2<openrand::Philox>(12345);
+  test_rangev2<openrand::Tyche>(1234);
+}


### PR DESCRIPTION
Code mostly taken from [here](https://lemire.me/blog/2016/06/30/fast-random-shuffling/), credits to Lemire.

For range N and floating point types, we use the basic `rand() * N` formula in the `uniform` method. 

For integral type, `uniform` by default uses biased version. Users can use non-biased verison by directly invoking `range`.